### PR TITLE
refactor: remove explicit Grok case from LLM provider switch

### DIFF
--- a/cmd/commit-msg/main.go
+++ b/cmd/commit-msg/main.go
@@ -118,9 +118,7 @@ func main() {
 		case "chatgpt":
 			commitMsg, err = chatgpt.GenerateCommitMessage(config, changes, apiKey)
 		case "claude":
-			commitMsg, err = claude.GenerateCommitMessage(config, changes, apiKey)
-		case "grok":
-			commitMsg, err = grok.GenerateCommitMessage(config, changes, apiKey)
+			commitMsg, err = claude.GenerateCommitMessage(config, changes, apiKey)	
 		default:
 			commitMsg, err = grok.GenerateCommitMessage(config, changes, apiKey)
 		}


### PR DESCRIPTION
Removed the explicit Grok case, keeping Grok as the default fallback provider
