### PR TITLE
fix #69 : remove emojis from console output for professional appearance

### DIFF
--- a/cmd/cli/createMsg.go
+++ b/cmd/cli/createMsg.go
@@ -151,7 +151,7 @@ func CreateCommitMsg () {
 			os.Exit(1)
 		}
 
-		spinnerGenerating.Success("✅ Commit message generated successfully!")
+		spinnerGenerating.Success("Commit message generated successfully!")
 
 		pterm.Println()
 
@@ -161,9 +161,9 @@ func CreateCommitMsg () {
 		// Copy to clipboard
 		err = clipboard.WriteAll(commitMsg)
 		if err != nil {
-			pterm.Warning.Printf("⚠️  Could not copy to clipboard: %v\n", err)
+			pterm.Warning.Printf("Could not copy to clipboard: %v\n", err)
 		} else {
-			pterm.Success.Println("📋 Commit message copied to clipboard!")
+			pterm.Success.Println("Commit message copied to clipboard!")
 		}
 
 		pterm.Println()

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -18,7 +18,7 @@ type FileStatistics struct {
 
 // ShowFileStatistics displays file statistics with colored output
 func ShowFileStatistics(stats *FileStatistics) {
-	pterm.DefaultSection.Println("📊 Changes Summary")
+	pterm.DefaultSection.Println("Changes Summary")
 
 	// Create bullet list items
 	bulletItems := []pterm.BulletListItem{}
@@ -26,7 +26,7 @@ func ShowFileStatistics(stats *FileStatistics) {
 	if len(stats.StagedFiles) > 0 {
 		bulletItems = append(bulletItems, pterm.BulletListItem{
 			Level:       0,
-			Text:        pterm.Green(fmt.Sprintf("✅ Staged files: %d", len(stats.StagedFiles))),
+			Text:        pterm.Green(fmt.Sprintf("Staged files: %d", len(stats.StagedFiles))),
 			TextStyle:   pterm.NewStyle(pterm.FgGreen),
 			BulletStyle: pterm.NewStyle(pterm.FgGreen),
 		})
@@ -49,7 +49,7 @@ func ShowFileStatistics(stats *FileStatistics) {
 	if len(stats.UnstagedFiles) > 0 {
 		bulletItems = append(bulletItems, pterm.BulletListItem{
 			Level:       0,
-			Text:        pterm.Yellow(fmt.Sprintf("⚠️  Unstaged files: %d", len(stats.UnstagedFiles))),
+			Text:        pterm.Yellow(fmt.Sprintf("Unstaged files: %d", len(stats.UnstagedFiles))),
 			TextStyle:   pterm.NewStyle(pterm.FgYellow),
 			BulletStyle: pterm.NewStyle(pterm.FgYellow),
 		})
@@ -72,7 +72,7 @@ func ShowFileStatistics(stats *FileStatistics) {
 	if len(stats.UntrackedFiles) > 0 {
 		bulletItems = append(bulletItems, pterm.BulletListItem{
 			Level:       0,
-			Text:        pterm.Cyan(fmt.Sprintf("📝 Untracked files: %d", len(stats.UntrackedFiles))),
+			Text:        pterm.Cyan(fmt.Sprintf("Untracked files: %d", len(stats.UntrackedFiles))),
 			TextStyle:   pterm.NewStyle(pterm.FgCyan),
 			BulletStyle: pterm.NewStyle(pterm.FgCyan),
 		})
@@ -97,7 +97,7 @@ func ShowFileStatistics(stats *FileStatistics) {
 
 // ShowCommitMessage displays the commit message in a styled panel
 func ShowCommitMessage(message string) {
-	pterm.DefaultSection.Println("📝 Generated Commit Message")
+	pterm.DefaultSection.Println("Generated Commit Message")
 
 	// Create a panel with the commit message
 	panel := pterm.DefaultBox.
@@ -116,7 +116,7 @@ func ShowCommitMessage(message string) {
 
 // ShowChangesPreview displays a preview of changes with line statistics
 func ShowChangesPreview(stats *FileStatistics) {
-	pterm.DefaultSection.Println("🔍 Changes Preview")
+	pterm.DefaultSection.Println("Changes Preview")
 
 	// Create info boxes
 	if stats.LinesAdded > 0 || stats.LinesDeleted > 0 {


### PR DESCRIPTION
- Removed emojis from section headers, bullet points, and status messages
- Updated display.go and createMsg.go to use plain text instead of emojis

<img width="773" height="443" alt="image" src="https://github.com/user-attachments/assets/8c823164-0146-4d2a-98ad-d1a4649aeed0" />
